### PR TITLE
Dynamically look up shell executable path.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,13 +8,12 @@
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "name": "nodemon",
-            "envFile": "${workspaceFolder}/.env.development.local",
             "request": "launch",
             "restart": true,
             "runtimeExecutable": "concurrently",
             "args": [
                 "\"npx tsc --watch\"",
-                "\"nodemon ${workspaceFolder}/build/main.js\""
+                "\"nodemon --env-file ${workspaceFolder}/.env.development.local ${workspaceFolder}/build/main.js\""
             ],
             "skipFiles": [
                 "<node_internals>/**"

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nighttune-backend",
       "version": "2.7.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "postinstall": "npm install -g oref0",
     "postbuild": "npx copyfiles ./src/templates/*.ejs ./build",
     "initdb": "./scripts/initdb.sh",
     "start": "dotenvx run --convention=nextjs -- node build/main.js",

--- a/src/dao/nightscout.ts
+++ b/src/dao/nightscout.ts
@@ -4,13 +4,29 @@ import { sgg } from 'ml-savitzky-golay-generalized'
 import { spawn } from 'node:child_process'
 import { subtle } from 'node:crypto'
 import fs from 'node:fs/promises'
+import fsSync from 'node:fs'
 import { join } from 'node:path'
 import { type } from 'arktype'
 
 import logger from '../logger.js'
-import { NightscoutProfileStore as NightscoutProfileStoreT } from '../models/nightscout.js'
+import { NightscoutProfileStore as NightscoutProfileStoreT, UnauthorizedError } from '../models/nightscout.js'
 import { AutotuneConfig, AutotuneErrorType, AutotuneJob as AutotuneJobT, JobId, SmoothingLevel } from '../models/job.js'
 import { AutotuneResult, BasalRecommendation, PostProcessType } from '../services/recommendationsParser.js'
+
+const shell_executable = (): string => {
+    const shell = process.env.SHELL!
+
+    try {
+        const stat = fsSync.statSync(shell)
+        if (stat.isFile()) {
+            return shell
+        }
+
+        throw new Error(`No such shell ${shell}`)
+    } catch (error: any) {
+        throw new Error(`stat() failed: ${error.message}`)
+    }
+}
 
 type NightscoutProfileStore = typeof NightscoutProfileStoreT.infer
 type SmoothingLevel = typeof AutotuneJobT.infer.settings.basal_smoothing
@@ -116,6 +132,14 @@ const findAutotuneLogFile = async (tempdir: string): Promise<string | undefined>
 
 export class NightscoutDao {
 
+    private readonly shell: string
+
+    constructor() {
+        // If there is no shell in the $SHELL env variable, calling
+        // this method here will prevent nighttune-backend from starting up.
+        this.shell = shell_executable()
+    }
+
     /**
      * Verifies whether the Nightscout API can be accessed using the given url and optional token.
      * 
@@ -203,11 +227,12 @@ export class NightscoutDao {
             `--end-date=${format(endDate, 'yyyy-MM-dd')}`,
             `--categorize-uam-as-basal=${config.job.settings.uam_as_basal}`
         ]
+
         const oref0_autotune = spawn(`${command} ${flags.join(' ')}`,
         {
             detached: true,
             env: {...process.env, 'API_SECRET': token},
-            shell: '/usr/bin/bash',
+            shell: this.shell,
             stdio: ['pipe', 'ignore', 'pipe'],
             timeout: 5 * 60 * 1000
         })
@@ -279,10 +304,12 @@ export class NightscoutDao {
      * @param profile The Nightscout profile to upload.
      * @param nsUrl The Nightscout site URL.
      * @param token The optional Nightscout access token.
+     * 
+     * @throws `UnauthorizedError` if the Nightscout site returns an HTTP 401 status
+     * @throws `Error` In all other error cases.
      */
     async addProfile(profile: NightscoutProfileStore, nsUrl: URL, token?: string): Promise<void> {
         const url = await addToken(new URL("api/v1/profile", nsUrl), token)
-
         const response = await fetch(url, {
             method: 'POST',
             body: JSON.stringify(profile)
@@ -292,8 +319,12 @@ export class NightscoutDao {
             return Promise.resolve()
         }
 
-        const msg = `Could not add profile to Nightscout site at ${nsUrl.href}: HTTP response code was ${response.status}`
-        logger.error(msg)
-        return Promise.reject(msg)
+        switch (response.status) {
+            case 401: throw new UnauthorizedError(nsUrl.href)
+            default:
+                const msg = `Could not add profile to Nightscout site at ${nsUrl.href}: HTTP response code was ${response.status}`
+                logger.error(msg)
+                return Promise.reject(new Error(msg))
+        }
     }
 }

--- a/src/dao/sqlite.ts
+++ b/src/dao/sqlite.ts
@@ -265,7 +265,12 @@ export class SqliteDao {
              WHERE `jobs`.`uuid` = @uuid\
              AND `jobs`.`ns_url` = @url', { url: url.href, uuid })
 
-        return row === undefined ? undefined : JSON.parse(row.recommendations, POST_PROCESSING_REVIVER) as AutotuneResult
+        if (row === undefined) {
+            return undefined
+        }
+
+        const obj = JSON.parse(row!.recommendations, POST_PROCESSING_REVIVER)
+        return new AutotuneResult(obj.recommendations, obj.options)
     }
 
     /**
@@ -283,7 +288,7 @@ export class SqliteDao {
             AND `jobs`.`ns_url` = @url', { url: url.href, uuid })
 
         if (row) {
-            const parameters = AutotuneJobT(row!.parameters)
+            const parameters = AutotuneJobT(JSON.parse(row!.parameters))
             if (parameters instanceof type.errors) {
                 logger.error(`Cannot parse job[${uuid}].parameters into AutotuneJob:\n${parameters.summary}`)
                 throw new Error('Cannot parse job parameters into AutotuneJob')

--- a/src/models/nightscout.ts
+++ b/src/models/nightscout.ts
@@ -1,6 +1,13 @@
 import { type } from 'arktype'
 import { Unit } from './job.js'
 
+export class UnauthorizedError extends Error {
+    
+    constructor(message: string, cause?: any) {
+        super(message, { cause })
+    }
+}
+
 export class NoSuchProfileError extends Error {
     public readonly profileName: string
 

--- a/src/routes/job.ts
+++ b/src/routes/job.ts
@@ -14,7 +14,7 @@ import { SqliteDao } from '../dao/sqlite.js'
 import logger from '../logger.js'
 import { AutotuneJob, CreateProfileRequest, GenericDatabaseError, JobAlreadyEnqueuedError, JobExecutionError, NoSuchJobError } from '../models/job.js'
 import { ProfileService } from '../services/profileService.js'
-import { NoSuchProfileError, ProfileAlreadyExistsError } from '../models/nightscout.js'
+import { NoSuchProfileError, ProfileAlreadyExistsError, UnauthorizedError } from '../models/nightscout.js'
 
 const corsOptions: CorsOptions = {
     origin: process.env.NT_CORS_ALLOWED_ORIGINS?.split(',') || [],
@@ -97,7 +97,10 @@ router.post('/id/:id/create-ns-profile', cors(corsOptions), async (request: Requ
         try {
             await controller.createAndUploadProfile(createProfileRequest.name, request.params.id, new URL(session.verifiedNightscoutUrl!), session.verifiedNightscoutToken)
         } catch (error: any) {
-            if (error instanceof NoSuchJobError) {
+            if (error instanceof UnauthorizedError) {
+                logger.error(`Uploading profile for job ${request.params.id} failed: Unauthorized.`)
+                response.status(401).json({message: 'Unauthorized. Maybe you\'re using a read-only token?'})
+            } else if (error instanceof NoSuchJobError) {
                 logger.error(`Cannot create profile for job ${request.params.id}: ${error.message}`)
                 response.status(404).json({message: `No such job ${request.params.id}`})
             } else if (error instanceof NoSuchProfileError) {
@@ -107,7 +110,7 @@ router.post('/id/:id/create-ns-profile', cors(corsOptions), async (request: Requ
                 logger.error(`Cannot create profile for job ${request.params.id}: A profile named ${error.profileName} already exists.`)
                 response.status(409).json({message: `A profile named ${error.profileName} already exists.`})
             } else {
-                logger.error(`Error while creating a new profile at ${session.verifiedNightscoutUrl!} for job ${request.params.id}:\n${JSON.stringify(error)}`)
+                logger.error(`Error while creating a new profile at ${session.verifiedNightscoutUrl!} for job ${request.params.id}:\n${error.message}`)
                 response.status(500).json({message: 'Error while creating profile.'})
             }
         }

--- a/src/services/recommendationsParser.ts
+++ b/src/services/recommendationsParser.ts
@@ -185,7 +185,7 @@ export class AutotuneResult {
 
     private readonly recommendations: Recommendation[]
 
-    constructor(recommendations: Recommendation[], options: AutotuneOptions | undefined) {
+    constructor(recommendations: Recommendation[], options?: AutotuneOptions) {
         this.options = options
         this.recommendations = recommendations;
     }


### PR DESCRIPTION
This is done in the NightscoutDao since it spawns a new process for autotune jobs. This allows for different default shells on different (testing) systems.

Additionally:
- Install oref0 globally in postinstall script.
- Return HTTP 401 if profile cannot be uploaded due to lack of authorization of current token.