### PR TITLE
Remove unneeded docker desktop socket checks

### DIFF
--- a/scripts/docker-image.sh
+++ b/scripts/docker-image.sh
@@ -78,16 +78,9 @@ prepare_directories () {
 require_docker_running () {
     docker info &> /dev/null
     if [ "$?" -ne 0 ]; then
-        # Check known socket paths, including WSL2 Docker Desktop locations.
-        if [ ! -e '/var/run/docker.sock' ] && \
-           [ ! -e "${HOME}/.docker/desktop/docker.sock" ] && \
-           [ ! -e '/mnt/wsl/docker-desktop/shared-sockets/guest-services/backend.sock' ]; then
-            if grep -qi microsoft /proc/version 2>/dev/null; then
-                echo >&2 "Docker seems not to be running. If you are using Docker Desktop on Windows, ensure WSL integration is enabled for this distro in Docker Desktop settings (Settings > Resources > WSL Integration)."
-            else
-                echo >&2 "Docker seems not to be running, please start it first."
-            fi
-        else
+        if [ ! -e '/var/run/docker.sock' ]; then
+            echo >&2 "Docker seems not to be running, please start it first."
+        else 
             echo >&2 "Could not successfully retrieve docker status, please ensure it is running without error."
         fi
 


### PR DESCRIPTION
I just noticed my typo corrections PR for the backend included potentially unnecessary docker socket paths I was checking during troubleshooting of docker desktop 

https://github.com/houthacker/nighttune-backend/pull/164/changes#diff-090c30899dee381723a9fdde7ceb8ed16428ddadccb7fcfea02a116082c17249

This removes the #81-83 -> #81 -> #90 change as it proved unneeded. The primary issue was the checkbox in the docker desktop settings.