### PR TITLE
Fix Nightscout API v3 compatibility for profile creation

### DIFF
--- a/src/dao/nightscout/v3.ts
+++ b/src/dao/nightscout/v3.ts
@@ -167,6 +167,8 @@ export class NightscoutApiV3 extends NightscoutApiV1 implements NightscoutApi {
             delete payloadForCreate._id
             delete payloadForCreate.identifier
             delete payloadForCreate.utcOffset
+            delete payloadForCreate.eventType
+            delete payloadForCreate.device
             delete payloadForCreate.srvCreated
             delete payloadForCreate.srvModified
             delete payloadForCreate.subject

--- a/src/dao/nightscout/v3.ts
+++ b/src/dao/nightscout/v3.ts
@@ -152,13 +152,36 @@ export class NightscoutApiV3 extends NightscoutApiV1 implements NightscoutApi {
         const profileUrl = new URL('/api/v3/profile', url)
 
         try {
+            const now = Date.now()
+            const normalizedPayload = {
+                ...profile,
+                date: now,
+                app: typeof profile.app === 'string' && profile.app.trim().length > 0
+                    ? profile.app
+                    : 'Nighttune',
+            }
+
+            // API v3 create rejects immutable/server-managed fields in client payload.
+            // Remove them here.
+            const payloadForCreate = {...normalizedPayload} as Record<string, unknown>
+            delete payloadForCreate._id
+            delete payloadForCreate.identifier
+            delete payloadForCreate.utcOffset
+            delete payloadForCreate.srvCreated
+            delete payloadForCreate.srvModified
+            delete payloadForCreate.subject
+            delete payloadForCreate.modifiedBy
+            delete payloadForCreate.isValid
+
+            const payload = payloadForCreate as ProfileStore
+
             const headers = {
                 'Content-Type' : 'application/json',
                 ...await this.requiredHeaders(url, token)
             }
             const response = await fetch(profileUrl, {
                 method: 'POST',
-                body: JSON.stringify(profile),
+                body: JSON.stringify(payload),
                 headers
             })
 
@@ -171,7 +194,8 @@ export class NightscoutApiV3 extends NightscoutApiV1 implements NightscoutApi {
                 case 403: throw new AccessDeniedError(url.href)
                 case 422: throw new ProfileModificationError(url.href)
                 default:
-                    const msg = `Could not add profile to Nightscout site at ${url.href}: HTTP response code was ${response.status}`
+                    const responseText = await response.text()
+                    const msg = `Could not add profile to Nightscout site at ${url.href}: HTTP response code was ${response.status}. Nightscout response: ${responseText}`
                     logger.error(msg)
                     return Promise.reject(new Error(msg))
             }

--- a/src/services/profileService.ts
+++ b/src/services/profileService.ts
@@ -89,8 +89,16 @@ export class ProfileService {
             return a.timeAsSeconds - b.timeAsSeconds
         })
 
-        // Copy current store and add profile to it. Remove the id to ensure a new id will be asssigned.
-        const {_id, ...newStore} = {...profileStore} as NightscoutProfileStore
+        // Copy current store and add profile to it. Remove the id to ensure a new id will be assigned.
+        const createdAt = new Date().toISOString()
+        const { _id, store, ...storeMeta } = profileStore
+        const newStore = {
+            ...storeMeta,
+            defaultProfile: name,
+            startDate: createdAt,
+            created_at: createdAt,
+            store: { ...store },
+        } as NightscoutProfileStore
         newStore.store[name] = newProfile
 
         return newStore

--- a/tests/services/profileService.test.ts
+++ b/tests/services/profileService.test.ts
@@ -1,13 +1,13 @@
 import { parseJSON } from 'date-fns'
+import { Assert, AssertStrict } from 'node:assert'
 import { readFileSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import { test } from 'node:test'
-import { Assert, AssertStrict }  from 'node:assert'
+import { fileURLToPath } from 'node:url'
 
-import { NightscoutProfileStore } from '../../src/models/nightscout.js'
 import { AutotuneJob as AutotuneJobT } from '../../src/models/job.js'
-import { AutotuneOptions, AutotuneResult, Recommendation } from '../../src/services/recommendationsParser.js'
+import { NightscoutProfileStore } from '../../src/models/nightscout.js'
 import { ProfileService } from '../../src/services/profileService.js'
+import { AutotuneOptions, AutotuneResult, Recommendation, roundToNext } from '../../src/services/recommendationsParser.js'
 
 const service = new ProfileService()
 
@@ -23,12 +23,29 @@ const jsonFixture = (name: string): any => {
 
 test('Create a new profile from job results', (_) => {
     const profileName = "Autotune"
-    const expectedProfile = NightscoutProfileStore(jsonFixture('new_profile_no_post_processing.json')) as typeof NightscoutProfileStore.infer
     const profilesFromNightscout = NightscoutProfileStore((jsonFixture('api_v1_profile.json') as any[])[0]) as typeof NightscoutProfileStore.infer
     const parameters = AutotuneJobT(jsonFixture('job_parameters.json')) as typeof AutotuneJobT.infer
     const {options, recommendations} = jsonFixture('job_results.json') as {options: AutotuneOptions | undefined, recommendations: Recommendation[]}
-    const profile = service.createProfileFromJobResults(profileName, profilesFromNightscout, parameters.settings.profile_name, new AutotuneResult(recommendations, options))
+    const results = new AutotuneResult(recommendations, options)
+    const profile = service.createProfileFromJobResults(profileName, profilesFromNightscout, parameters.settings.profile_name, results)
 
     const assert: AssertStrict = new Assert({ diff: 'full' })
-    assert.deepEqual(profile, expectedProfile)
+    assert.equal(profile.defaultProfile, profileName)
+    assert.equal(Object.hasOwn(profile.store, profileName), true)
+    assert.equal(Object.hasOwn(profilesFromNightscout.store, profileName), false)
+    assert.notEqual(profile.startDate, profilesFromNightscout.startDate)
+    assert.notEqual(profile.created_at, profilesFromNightscout.created_at)
+
+    const createdProfile = profile.store[profileName]
+    assert.deepEqual(createdProfile.carbratio, [{
+        time: '00:00',
+        timeAsSeconds: 0,
+        value: roundToNext(results.find_cr().recommendedValue, results.options!.basalIncrement),
+    }])
+    assert.deepEqual(createdProfile.sens, [{
+        time: '00:00',
+        timeAsSeconds: 0,
+        value: roundToNext(results.find_isf().recommendedValue, results.options!.basalIncrement),
+    }])
+    assert.doesNotThrow(() => JSON.parse(JSON.stringify(profile)))
 })


### PR DESCRIPTION
- Update the profile upload process to satisfy API v3 requirements by stripping server-managed and immutable fields that cause request rejection.
- Add a fresh timestamp and default app name to prevent collisions.
- Add improved error logging to include the response body from Nightscout.
- Update test services
